### PR TITLE
[QOL-9275] repeat the 'changes_multiple' route definition

### DIFF
--- a/ckanext/qgov/common/views/dataset.py
+++ b/ckanext/qgov/common/views/dataset.py
@@ -77,7 +77,10 @@ def resource_read(package_type, id, resource_id):
     return resource.read(package_type, id, resource_id)
 
 
+# Any core routes that would match an <id> pattern, such as 'new',
+# must be repeated here, or else they will be overridden.
 _dataset.add_url_rule(u'new', view_func=dataset.CreateView.as_view('new'))
+_dataset.add_url_rule(u'changes_multiple', 'changes_multiple', view_func=dataset.changes_multiple)
 _dataset.add_url_rule(u'<id>', view_func=dataset_read)
 _dataset.add_url_rule(u'<id>/resource/new', view_func=resource.CreateView.as_view('new_resource'))
 _dataset.add_url_rule(u'<id>/resource/<resource_id>', view_func=resource_read)


### PR DESCRIPTION
- Any core routes that match one of our wildcard routes, eg '/dataset/new' matching '/dataset/<id>',
must be repeated in our plugin or else they'll be overridden by the wildcard.