### PR TITLE
Develop to master

### DIFF
--- a/ckanext/qgov/common/plugin.py
+++ b/ckanext/qgov/common/plugin.py
@@ -95,6 +95,11 @@ class QGOVPlugin(SingletonPlugin):
         implements(plugins.IBlueprint)
     if check_ckan_version(max_version='2.8.99'):
         implements(plugins.IRoutes, inherit=True)
+    if check_ckan_version('2.10'):
+        implements(plugins.IAuthenticator)
+
+        def authenticate(identity):
+            return authenticator.qgov_authenticate(identity)
 
     # IConfigurer
 
@@ -169,7 +174,8 @@ class QGOVPlugin(SingletonPlugin):
         """ Monkey-patch functions that don't have standard extension
         points.
         """
-        authenticator.intercept_authenticator()
+        if not check_ckan_version('2.10'):
+            authenticator.intercept_authenticator()
         intercepts.configure(config)
         intercepts.set_intercepts()
         if check_ckan_version(max_version='2.8.99'):


### PR DESCRIPTION
Add CKAN 2.10 support to authenticator. The structure has changed to make it easier to customise the authentication process via plugin, but is not backwards compatible.