### PR TITLE
QOLDEV-313 prepare for CKAN 2.10

### DIFF
--- a/ckanext/qgov/common/authenticator.py
+++ b/ckanext/qgov/common/authenticator.py
@@ -13,39 +13,36 @@ LOGIN_THROTTLE_EXPIRY = 1800
 
 
 if check_ckan_version('2.10'):
-    from ckan.lib.authenticator import default_authenticate
+    from ckan.lib import authenticator as core_authenticator
+    from ckan.lib.authenticator import default_authenticate as core_authenticate
 else:
+    from zope.interface import implementer
+    from repoze.who.interfaces import IAuthenticator
     from ckan.lib.authenticator import UsernamePasswordAuthenticator
-    default_authenticate = UsernamePasswordAuthenticator.authenticate
+
+    core_authenticate = UsernamePasswordAuthenticator.authenticate
+
+    @implementer(IAuthenticator)
+    class QGOVAuthenticator(UsernamePasswordAuthenticator):
+        """ Extend UsernamePasswordAuthenticator so it's possible to
+        configure this via who.ini.
+        """
+
+        def authenticate(self, environ, identity):
+            """ Mimic most of UsernamePasswordAuthenticator.authenticate
+            but add account lockout after 10 failed attempts.
+            """
+            def authenticate_wrapper(identity):
+                return core_authenticate(self, environ, identity)
+            return qgov_authenticate(identity, authenticate_wrapper)
 
 
 def intercept_authenticator():
     """ Replaces the existing authenticate function with our custom one.
     """
     if check_ckan_version('2.10'):
-        from ckan.lib import authenticator as core_authenticator
-
         core_authenticator.default_authenticate = qgov_authenticate
     else:
-        from zope.interface import implementer
-        from repoze.who.interfaces import IAuthenticator
-
-        from ckan.lib.authenticator import UsernamePasswordAuthenticator
-
-        @implementer(IAuthenticator)
-        class QGOVAuthenticator(UsernamePasswordAuthenticator):
-            """ Extend UsernamePasswordAuthenticator so it's possible to
-            configure this via who.ini.
-            """
-
-            def authenticate(self, environ, identity):
-                """ Mimic most of UsernamePasswordAuthenticator.authenticate
-                but add account lockout after 10 failed attempts.
-                """
-                def core_authenticate(identity):
-                    return default_authenticate(self, environ, identity)
-                return qgov_authenticate(identity, core_authenticate)
-
         UsernamePasswordAuthenticator.authenticate = QGOVAuthenticator().authenticate
 
 
@@ -64,7 +61,7 @@ def unlock_account(account_id):
         LOG.debug("Account %s not found", account_id)
 
 
-def qgov_authenticate(identity, core_authenticate=default_authenticate):
+def qgov_authenticate(identity, core_authenticate=core_authenticate):
     """ Mimic most of UsernamePasswordAuthenticator.authenticate
     but add account lockout after 10 failed attempts.
     """

--- a/ckanext/qgov/common/plugin.py
+++ b/ckanext/qgov/common/plugin.py
@@ -95,11 +95,6 @@ class QGOVPlugin(SingletonPlugin):
         implements(plugins.IBlueprint)
     if check_ckan_version(max_version='2.8.99'):
         implements(plugins.IRoutes, inherit=True)
-    if check_ckan_version('2.10'):
-        implements(plugins.IAuthenticator, inherit=True)
-
-        def authenticate(self, identity):
-            return authenticator.qgov_authenticate(identity)
 
     # IConfigurer
 
@@ -174,8 +169,7 @@ class QGOVPlugin(SingletonPlugin):
         """ Monkey-patch functions that don't have standard extension
         points.
         """
-        if not check_ckan_version('2.10'):
-            authenticator.intercept_authenticator()
+        authenticator.intercept_authenticator()
         intercepts.configure(config)
         intercepts.set_intercepts()
         if check_ckan_version(max_version='2.8.99'):

--- a/test/features/steps/steps.py
+++ b/test/features/steps/steps.py
@@ -92,7 +92,9 @@ def fill_in_field_if_present(context, name, value):
 def add_resource(context, name, url):
     context.execute_steps(u"""
         When I log in
-        And I visit "/dataset/new_resource/test-dataset"
+        And I edit the "test-dataset" dataset
+        And I click the link with text that contains "Resources"
+        And I click the link with text that contains "Add new resource"
         And I execute the script "$('#resource-edit [name=url]').val('{url}')"
         And I fill in "name" with "{name}"
         And I fill in "description" with "description"


### PR DESCRIPTION
Adjust authenticator integration to monkey-patch the original, so that we can prevent the default authentication from working when accounts are locked.