### PR TITLE
QOLDEV-313 support CKAN 2.10 and drop 2.8

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -137,9 +137,6 @@ commands:
     usage: Run BDD tests.
     cmd: |
       ahoy start-mailmock &
-      if [ "$CKAN_VERSION" = "2.8" ]; then
-        BEHAVE_TAGS="--tags=-ckan29"
-      fi
       sleep 5 &&
       ahoy cli "behave -k ${*:-test/features}" --tags=smoke $BEHAVE_TAGS && \
       ahoy cli "behave -k ${*:-test/features} $BEHAVE_TAGS" || \

--- a/.docker/test.ini
+++ b/.docker/test.ini
@@ -13,7 +13,7 @@
 
 [DEFAULT]
 debug = false
-smtp_server = localhost
+smtp_server = localhost:8025
 error_email_from = paste@localhost
 
 [server:main]
@@ -167,6 +167,7 @@ ckan.hide_activity_from_users = %(ckan.site_id)s
 #smtp.mail_from =
 # If 'smtp.test_server' is configured we assume we're running tests,
 # and don't use the smtp.server, starttls, user, password etc. options.
+smtp.server = localhost:8025
 smtp.test_server = localhost:8025
 smtp.mail_from = info@test.ckan.net
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,15 +44,7 @@ jobs:
         timeout-minutes: 15
 
       - name: Test
-        run: |
-          ahoy lint
-          ahoy test-unit
-        timeout-minutes: 10
-
-      - name: Test BDD
-        run: |
-           ahoy install-site
-           ahoy test-bdd
+        run: bin/test.sh
         timeout-minutes: 30
 
       - name: Retrieve logs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,15 @@ jobs:
         timeout-minutes: 15
 
       - name: Test
-        run: bin/test.sh
+        run: |
+          ahoy lint
+          ahoy test-unit
+        timeout-minutes: 10
+
+      - name: Test BDD
+        run: |
+           ahoy install-site
+           ahoy test-bdd
         timeout-minutes: 30
 
       - name: Retrieve logs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ckan-version: [2.9, 2.9-py2]
+        ckan-version: ["2.10", 2.9, 2.9-py2]
         ckan-type: ['vanilla', 'custom']
 
     name: Test on CKAN ${{ matrix.ckan-version }} ${{ matrix.ckan-type }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ckan-version: [2.9, 2.9-py2, 2.8]
+        ckan-version: [2.9, 2.9-py2]
         ckan-type: ['vanilla', 'custom']
 
     name: Test on CKAN ${{ matrix.ckan-version }} ${{ matrix.ckan-type }}

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -19,13 +19,7 @@ PYTHON=python
 CKAN_GIT_VERSION=$CKAN_VERSION
 CKAN_GIT_ORG=ckan
 
-if [ "$CKAN_VERSION" = "2.8" ]; then
-    PYTHON_VERSION=py2
-    if [ "$CKAN_TYPE" = "custom" ]; then
-      CKAN_GIT_VERSION=ckan-2.8.8-qgov.5
-      CKAN_GIT_ORG=qld-gov-au
-    fi
-elif [ "$CKAN_VERSION" = "2.10" ]; then
+if [ "$CKAN_VERSION" = "2.10" ]; then
     PYTHON_VERSION=py3
     PYTHON="${PYTHON}3"
 else

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -11,4 +11,6 @@ echo "==> Run Unit tests"
 ahoy test-unit
 
 echo "==> Run BDD tests"
+ahoy install-site
+ahoy cli "rm -r test/screenshots || true"
 ahoy test-bdd || (ahoy logs; exit 1)

--- a/ckanext/qgov/common/authenticator.py
+++ b/ckanext/qgov/common/authenticator.py
@@ -3,6 +3,7 @@
 """
 
 import logging
+
 from ckan.lib.redis import connect_to_redis
 from ckan.model import User, Session
 from ckan.plugins.toolkit import check_ckan_version, config

--- a/ckanext/qgov/common/stats.py
+++ b/ckanext/qgov/common/stats.py
@@ -3,7 +3,7 @@
 """
 from ckan import model
 from sqlalchemy import and_, func, select, Table
-import six
+from six import text_type as str
 
 
 def table(name):
@@ -36,7 +36,7 @@ class Stats(object):
             limit(limit)
 
         res_ids = model.Session.execute(query).fetchall()
-        res_groups = [(model.Session.query(model.Group).get(six.text_type(group_id)), val) for group_id, val in res_ids]
+        res_groups = [(model.Session.query(model.Group).get(str(group_id)), val) for group_id, val in res_ids]
         return res_groups
 
     @classmethod
@@ -51,7 +51,7 @@ class Stats(object):
             limit(limit)
 
         res_ids = model.Session.execute(query).fetchall()
-        res_groups = [(model.Session.query(model.Group).get(six.text_type(owner_org)), val) for owner_org, val in res_ids]
+        res_groups = [(model.Session.query(model.Group).get(str(owner_org)), val) for owner_org, val in res_ids]
         return res_groups
 
     @classmethod

--- a/ckanext/qgov/common/views/user.py
+++ b/ckanext/qgov/common/views/user.py
@@ -1,27 +1,14 @@
 # encoding: utf-8
 
-import six
+from six import text_type as str
 
 from flask import Blueprint
 
 import ckan.lib.helpers as h
-from ckan.plugins.toolkit import _, check_ckan_version, g, request,\
-    redirect_to, url_for
+from ckan.plugins.toolkit import _, g, request, redirect_to, url_for
 from ckan.views.user import login, me, EditView
 
 blueprint = Blueprint(u'user_overrides', __name__)
-
-
-def dashboard_override(offset=0):
-    """
-    Override default CKAN behaviour of throwing 403 Unauthorised exception for /dashboard[/] page and instead
-    redirect the user to the login page.
-    Ref.: ckan/views/dashboard.py > def index(...)
-    :param offset:
-    :return:
-    """
-    from ckan.views.dashboard import index
-    return index(offset) if g.user else redirect_to(url_for(u'user.login'))
 
 
 def logged_in_override():
@@ -32,7 +19,7 @@ def logged_in_override():
     """
     if g.user:
         came_from = request.params.get(u'came_from', None)
-        return redirect_to(six.text_type(came_from)) if came_from and h.url_is_local(came_from) else me()
+        return redirect_to(str(came_from)) if came_from and h.url_is_local(came_from) else me()
     else:
         h.flash_error(_(u'Login failed. Bad username or password.'))
         return login()
@@ -54,16 +41,6 @@ def user_edit_override():
 
 blueprint.add_url_rule(u'/user/logged_in', u'logged_in', logged_in_override)
 blueprint.add_url_rule(u'/user/edit', u'edit', user_edit_override)
-
-# redirect dashboard to login page if not logged in.
-# CKAN 2.9 handles this automatically.
-# CKAN 2.10 breaks it but will hopefully fix it in future,
-#  see https://github.com/ckan/ckan/issues/7507
-
-if not check_ckan_version('2.9'):
-    blueprint.add_url_rule(
-        u'/dashboard/', u'dashboard', dashboard_override,
-        strict_slashes=False, defaults={u'offset': 0})
 
 
 def get_blueprints():

--- a/ckanext/qgov/common/views/user.py
+++ b/ckanext/qgov/common/views/user.py
@@ -5,7 +5,8 @@ import six
 from flask import Blueprint
 
 import ckan.lib.helpers as h
-from ckan.plugins.toolkit import _, check_ckan_version, g, request, redirect_to, url_for
+from ckan.plugins.toolkit import _, check_ckan_version, g, request,\
+    redirect_to, url_for
 from ckan.views.user import login, me, EditView
 
 blueprint = Blueprint(u'user_overrides', __name__)
@@ -53,8 +54,13 @@ def user_edit_override():
 
 blueprint.add_url_rule(u'/user/logged_in', u'logged_in', logged_in_override)
 blueprint.add_url_rule(u'/user/edit', u'edit', user_edit_override)
+
+# redirect dashboard to login page if not logged in.
+# CKAN 2.9 handles this automatically.
+# CKAN 2.10 breaks it but will hopefully fix it in future,
+#  see https://github.com/ckan/ckan/issues/7507
+
 if not check_ckan_version('2.9'):
-    # CKAN 2.9+ handles non-logged-in users gracefully
     blueprint.add_url_rule(
         u'/dashboard/', u'dashboard', dashboard_override,
         strict_slashes=False, defaults={u'offset': 0})

--- a/test/features/homepage.feature
+++ b/test/features/homepage.feature
@@ -7,7 +7,6 @@ Feature: Homepage
         Given "Unauthenticated" as the persona
         When I go to homepage
 
-    @ckan29
     @homepage
     @unauthenticated
     Scenario: As a member of the public, when I go to the consistent asset URLs, I can see the asset

--- a/test/features/login_redirect.feature
+++ b/test/features/login_redirect.feature
@@ -5,7 +5,7 @@ Feature: Login Redirection
     Scenario Outline: As an unauthenticated user, when I visit the dashboard URL I see the login page
         Given "TestOrgMember" as the persona
         When I visit "<URL>"
-        Then I should see a login link
+        Then I should see the login form
         When I log in directly
         Then I should see "News feed"
 
@@ -18,7 +18,7 @@ Feature: Login Redirection
     Scenario: As an unauthenticated organisation member, when I visit the user edit URL I see the login page. Upon logging in I am taken to the user edit page
         Given "TestOrgMember" as the persona
         When I visit "/user/edit"
-        Then I should see a login link
+        Then I should see the login form
         When I log in directly
         Then I should see "Change details"
 
@@ -27,7 +27,7 @@ Feature: Login Redirection
     Scenario: As an unauthenticated user, when I visit the URL of a private dataset I see the login page
         Given "Unauthenticated" as the persona
         When I visit "/dataset/test-dataset"
-        Then I should see a login link
+        Then I should see the login form
 
     @public_dataset
     @unauthenticated
@@ -41,7 +41,7 @@ Feature: Login Redirection
     Scenario: As an unauthenticated organisation member, when I visit the URL of a private dataset I see the login page. Upon logging in I am taken to the private dataset
         Given "TestOrgMember" as the persona
         When I visit "/dataset/test-dataset"
-        Then I should see a login link
+        Then I should see the login form
         When I log in directly
         Then I should see "private test"
         And I should see an element with xpath "//span[contains(string(), 'Private')]"

--- a/test/features/login_redirect.feature
+++ b/test/features/login_redirect.feature
@@ -2,17 +2,12 @@
 Feature: Login Redirection
 
     @dashboard_login
-    Scenario Outline: As an unauthenticated user, when I visit the dashboard URL I see the login page
+    Scenario: As an unauthenticated user, when I visit the dashboard URL I see the login page
         Given "TestOrgMember" as the persona
-        When I visit "<URL>"
+        When I go to the dashboard
         Then I should see the login form
         When I log in directly
         Then I should see "News feed"
-
-        Examples: Dashboard URLs
-        | URL              |
-        | /dashboard       |
-        | /dashboard/      |
 
     @user_edit
     Scenario: As an unauthenticated organisation member, when I visit the user edit URL I see the login page. Upon logging in I am taken to the user edit page

--- a/test/features/organisations.feature
+++ b/test/features/organisations.feature
@@ -21,7 +21,7 @@ Feature: Organization APIs
         Examples: Non-admin users
             | Persona       |
             | Publisher     |
-            | Foodie        |
+            | Walker        |
             | Group Admin   |
 
     @unauthenticated

--- a/test/features/steps/steps.py
+++ b/test/features/steps/steps.py
@@ -155,7 +155,16 @@ def go_to_user_profile(context, user_id):
 
 @step(u'I go to the dashboard')
 def go_to_dashboard(context):
-    when_i_visit_url(context, '/dashboard')
+    context.execute_steps(u"""
+        When I visit "/dashboard/datasets"
+    """)
+
+
+@step(u'I should see my datasets')
+def dashboard_datasets(context):
+    context.execute_steps(u"""
+        Then I should see an element with xpath "//li[contains(@class, 'active') and contains(string(), 'My Datasets')]"
+    """)
 
 
 @step(u'I go to the "{user_id}" user API')

--- a/test/features/steps/steps.py
+++ b/test/features/steps/steps.py
@@ -64,7 +64,7 @@ def attempt_login(context, password):
     """.format(password))
 
 
-@step(u'I should see a login link')
+@step(u'I should see the login form')
 def login_link_visible(context):
     context.execute_steps(u"""
         Then I should see an element with xpath "//h1[contains(string(), 'Login')]"

--- a/test/features/users.feature
+++ b/test/features/users.feature
@@ -49,7 +49,7 @@ Feature: User APIs
     Scenario: User list is not accessible anonymously
         Given "Unauthenticated" as the persona
         When I go to the user list API
-        Then I should see an element with xpath "//*[contains(string(), '"success": false') and contains(string(), 'requires an authenticated user')]"
+        Then I should see an element with xpath "//*[contains(string(), '"success": false') and contains(string(), 'Authorization Error')]"
 
     Scenario Outline: User detail is accessible to admins
         Given "<Persona>" as the persona

--- a/test/features/users.feature
+++ b/test/features/users.feature
@@ -115,11 +115,12 @@ Feature: User APIs
         Given "Publisher" as the persona
         When I log in
         And I go to the dashboard
-        Then I should see an element with xpath "//h2[contains(string(), 'News feed')]"
+        Then I should see my datasets
+        And I should see "Add Dataset"
 
     @email
     Scenario: As a registered user, when I have locked my account with too many failed logins, I can reset my password to unlock it
-        Given "Walker" as the persona
+        Given "Foodie" as the persona
         When I lock my account
         And I go to "/user/login"
         And I attempt to log in with password "$password"


### PR DESCRIPTION
- Drop CKAN 2.8 code as it's no longer supported upstream
- Adjust dashboard tests to handle activity stream plugin split in CKAN 2.10