### PR TITLE
[QOLDEV-313] make file size formatter more robust

### DIFF
--- a/ckanext/qgov/common/helpers.py
+++ b/ckanext/qgov/common/helpers.py
@@ -36,7 +36,11 @@ def format_attribution_date(date_string=None):
 def format_resource_filesize(size):
     """ Show a file size, formatted for humans.
     """
-    return formatters.localised_filesize(int(size))
+    try:
+        return formatters.localised_filesize(int(size))
+    except ValueError:
+        # assume it's already formatted
+        return size
 
 
 def group_id_for(group_name):

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
     ],
 
     # What does your project relate to?


### PR DESCRIPTION
- Assume that non-numeric file sizes are already formatted, keep unchanged. This appears to be necessary on CKAN 2.10.