### PR TITLE
[QOLDEV-313] make auth check more robust

### DIFF
--- a/ckanext/qgov/common/helpers.py
+++ b/ckanext/qgov/common/helpers.py
@@ -75,7 +75,7 @@ def random_tags():
 def user_has_admin_access(include_editor_access):
     user = toolkit.c.userobj
     # If user is "None" - they are not logged in.
-    if user is None:
+    if not user:
         return False
     if user.sysadmin:
         return True


### PR DESCRIPTION
- Treat empty objects as 'no user', the same as None. This appears to be needed on CKAN 2.10.