### PR TITLE
QOLDEV-313 preparing for CKAN 2.10

### DIFF
--- a/ckanext/qgov/common/plugin.py
+++ b/ckanext/qgov/common/plugin.py
@@ -31,20 +31,6 @@ IP_ADDRESS = re.compile(r'^({0}[.]){{3}}{0}$'.format(r'[0-9]{1,3}'))
 PRIVATE_IP_ADDRESS = re.compile(r'^((1?0|127)([.]{0}){{3}}|(172[.](1[6-9]|2[0-9]|3[01])|169[.]254)([.]{0}){{2}}|192[.]168([.]{0}){{2}})$'.format(r'[0-9]{1,3}'))
 
 
-def legacy_pager(self, *args, **kwargs):
-    """ Construct a paging object suitable for Bootstrap 2.
-    See https://github.com/ckan/ckan/issues/4895
-    """
-    kwargs.update(
-        format=u"<div class='pagination-wrapper pagination'><ul>"
-        "$link_previous ~2~ $link_next</ul></div>",
-        symbol_previous=u'«', symbol_next=u'»',
-        curpage_attr={'class': 'active'}, link_attr={}
-    )
-    from ckan.lib.helpers import Page
-    return super(Page, self).pager(*args, **kwargs)
-
-
 def valid_url(key, flattened_data, errors, context):
     """ Check whether the value is a valid URL.
 
@@ -150,10 +136,6 @@ class QGOVPlugin(SingletonPlugin):
                     urlm_proxy = urlm_json[hostname].get('proxy', None)
                     urlm.configure_urlm(urlm_url, urlm_proxy)
 
-        if ckan_config.get('ckan.base_templates_folder',
-                           None) == 'templates-bs2':
-            from ckan.lib.helpers import Page
-            Page.pager = legacy_pager
         return ckan_config
 
     # IConfigurable

--- a/ckanext/qgov/common/resources/scheming_presets.json
+++ b/ckanext/qgov/common/resources/scheming_presets.json
@@ -6,7 +6,7 @@
     {
       "preset_name": "resource_url_upload",
       "values": {
-        "validators": "ignore_missing unicode remove_whitespace valid_url",
+        "validators": "ignore_missing unicode_safe remove_whitespace valid_url",
         "form_snippet": "upload.html",
         "form_placeholder": "http://example.com/my-data.csv",
         "upload_field": "upload",
@@ -17,7 +17,7 @@
     {
       "preset_name": "data_qld_resource_url_upload",
       "values": {
-        "validators": "scheming_required unicode remove_whitespace valid_url",
+        "validators": "scheming_required unicode_safe remove_whitespace valid_url",
         "form_snippet": "upload.html",
         "form_placeholder": "http://example.com/my-data.csv",
         "upload_field": "upload",

--- a/ckanext/qgov/common/templates/admin/config.html
+++ b/ckanext/qgov/common/templates/admin/config.html
@@ -3,6 +3,7 @@
 {% import 'macros/form.html' as form %}
 
 {% block admin_form %}
+{{ h.csrf_input() if 'csrf_input' in h }}
 
 {{ form.input('ckan.site_title', id='field-ckan-site-title', label=_('Site Title'), value=data['ckan.site_title'], error=error, classes=['control-medium']) }}
 


### PR DESCRIPTION
- Replace obsolete string-based validators with proper ones
- Drop obsolete Bootstrap 2 legacy pager